### PR TITLE
ksmbd: release 3.4.0 version

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -13,7 +13,7 @@
 #include "unicode.h"
 #include "vfs_cache.h"
 
-#define KSMBD_VERSION	"3.3.9"
+#define KSMBD_VERSION	"3.4.0"
 
 extern int ksmbd_debug_types;
 


### PR DESCRIPTION
Major changes are:
 - add support for SMB3 multichannel.
 - add support for FSCTL_DUPLICATE_EXTENTS_TO_FILE.
 - add support for AES256 encryption.
 - rename cifsd to ksmbd.
 - use generic asn1 decoder instead of own one.
 - remove cache read/trans buffer feature.
 - fix several bugs.
 - cleanup codes from review comments.

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>