### PR TITLE
ksmbd: fix possible wrong offset in REOPEN requests

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -3948,7 +3948,7 @@ int smb2_query_dir(struct ksmbd_work *work)
 
 	if (srch_flag & SMB2_REOPEN || srch_flag & SMB2_RESTART_SCANS) {
 		ksmbd_debug(SMB, "Restart directory scan\n");
-		generic_file_llseek(dir_fp->filp, 0, SEEK_SET);
+		vfs_llseek(dir_fp->filp, 0, SEEK_SET);
 		restart_ctx(&dir_fp->readdir_data.ctx);
 	}
 


### PR DESCRIPTION
In case underlying filesystem implement llseek other than
generic_file_llseek, vfs_llseek should be called instead of
generic_file_llseek.