### PR TITLE
dkms: fix permissioin problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,15 @@ install: ksmbd.ko
 # install dkms
 PKGVER=$(shell echo `git rev-parse --short HEAD`)
 dkms-install:
-	rm -rf "/usr/src/ksmbd*"
-	cp -r "$(PWD)" "/usr/src/ksmbd-$(PKGVER)"
-	sed -e "s/@VERSION@/$(PKGVER)/" -i "/usr/src/ksmbd-$(PKGVER)/dkms.conf"
-	dkms install -m ksmbd/$(PKGVER) --force
+	sudo rm -rf "/usr/src/ksmbd*"
+	sudo cp -r "$(PWD)" "/usr/src/ksmbd-$(PKGVER)"
+	sudo sed -e "s/@VERSION@/$(PKGVER)/" -i "/usr/src/ksmbd-$(PKGVER)/dkms.conf"
+	sudo dkms install -m ksmbd/$(PKGVER) --force
 
 dkms-uninstall:
-	modprobe -r ksmbd
-	dkms remove ksmbd/$(PKGVER)
-	rm -rf "/usr/src/ksmbd-$(PKGVER)"
+	sudo modprobe -r ksmbd
+	sudo dkms remove ksmbd/$(PKGVER)
+	sudo rm -rf "/usr/src/ksmbd-$(PKGVER)"
 
 uninstall:
 	rm -rf ${MDIR}/kernel/fs/ksmbd

--- a/vfs.c
+++ b/vfs.c
@@ -455,7 +455,8 @@ static int ksmbd_vfs_stream_write(struct ksmbd_file *fp, char *buf, loff_t *pos,
 {
 	char *stream_buf = NULL, *wbuf;
 	struct user_namespace *user_ns = file_mnt_user_ns(fp->filp);
-	size_t size, v_len;
+	ssize_t v_len;
+	size_t size;
 	int err = 0;
 
 	ksmbd_debug(VFS, "write stream data pos : %llu, count : %zd\n",
@@ -472,9 +473,9 @@ static int ksmbd_vfs_stream_write(struct ksmbd_file *fp, char *buf, loff_t *pos,
 				       fp->stream.name,
 				       fp->stream.size,
 				       &stream_buf);
-	if ((int)v_len < 0) {
+	if (v_len < 0) {
 		pr_err("not found stream in xattr : %zd\n", v_len);
-		err = (int)v_len;
+		err = v_len;
 		goto out;
 	}
 


### PR DESCRIPTION
`make dkms-install` need root permission, but code `PKGVER=$(shell echo \`git rev-parse --short HEAD\`)` cannot, so I add sudo for dkms cmds that need root permission.

![图片](https://user-images.githubusercontent.com/42114817/172680156-c901bb14-8bfd-47d1-8c47-ba70884adbdb.png)
