### PR TITLE
ksmbd: smb1: remove smb1_convert_to_nt_pathname

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -197,22 +197,6 @@ free_pathname:
 	return nt_pathname;
 }
 
-char *smb1_convert_to_nt_pathname(char *filename)
-{
-	char *ab_pathname;
-
-	if (strlen(filename) == 0)
-		filename = "\\";
-
-	ab_pathname = kstrdup(filename, GFP_KERNEL);
-	if (!ab_pathname)
-		return NULL;
-
-	ksmbd_conv_path_to_windows(ab_pathname);
-	return ab_pathname;
-}
-
-
 int get_nlink(struct kstat *st)
 {
 	int nlink;

--- a/misc.h
+++ b/misc.h
@@ -16,7 +16,6 @@ int ksmbd_validate_filename(char *filename);
 int parse_stream_name(char *filename, char **stream_name, int *s_type);
 char *convert_to_nt_pathname(struct ksmbd_share_config *share,
 			     const struct path *path);
-char *smb1_convert_to_nt_pathname(char *filename);
 int get_nlink(struct kstat *st);
 void ksmbd_conv_path_to_unix(char *path);
 void ksmbd_strip_last_slash(char *path);

--- a/vfs_cache.c
+++ b/vfs_cache.c
@@ -328,7 +328,6 @@ static void __ksmbd_close_fd(struct ksmbd_file_table *ft, struct ksmbd_file *fp)
 		kfree(smb_lock);
 	}
 
-	kfree(fp->filename);
 	if (ksmbd_stream_fd(fp))
 		kfree(fp->stream.name);
 	kmem_cache_free(filp_cache, fp);
@@ -489,16 +488,26 @@ struct ksmbd_file *ksmbd_lookup_fd_filename(struct ksmbd_work *work, char *filen
 {
 	struct ksmbd_file	*fp = NULL;
 	unsigned int		id;
+	char 			*pathname;
+
+	pathname = kmalloc(PATH_MAX, GFP_KERNEL);
+	if (!pathname)
+		return NULL;
 
 	read_lock(&work->sess->file_table.lock);
 	idr_for_each_entry(work->sess->file_table.idr, fp, id) {
-		if (!strcmp(fp->filename, filename)) {
+		char *path = d_path(&fp->filp->f_path, pathname, PATH_MAX);
+		if (IS_ERR(path))
+			break;
+
+		if (!strcmp(path, filename)) {
 			fp = ksmbd_fp_get(fp);
 			break;
 		}
 	}
 	read_unlock(&work->sess->file_table.lock);
 
+	kfree(pathname);
 	return fp;
 }
 #endif

--- a/vfs_cache.h
+++ b/vfs_cache.h
@@ -62,7 +62,6 @@ struct ksmbd_inode {
 
 struct ksmbd_file {
 	struct file			*filp;
-	char				*filename;
 	u64				persistent_id;
 	u64				volatile_id;
 
@@ -106,6 +105,9 @@ struct ksmbd_file {
 	unsigned long long		llock_fstart;
 
 	int				dirent_offset;
+
+	/* for find_first/find_next */
+	char 				*filename;
 #endif
 	/* if ls is happening on directory, below is valid*/
 	struct ksmbd_readdir_data	readdir_data;


### PR DESCRIPTION
SMB2 code stopped using the filename field from struct ksmbd_file since commit 7dcaaaa2e ("ksmbd: remove filename in ksmbd_file").

Adapt the SMB1 code to stop using it where possible. This lets us remove smb1_convert_to_nt_pathname().

Signed-off-by: Marios Makassikis <mmakassikis@freebox.fr>