### PR TITLE
ksmbd: add support for compound read request

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -189,40 +189,27 @@ int ksmbd_conn_write(struct ksmbd_work *work)
 	struct ksmbd_conn *conn = work->conn;
 	size_t len = 0;
 	int sent;
-	struct kvec iov[3];
-	int iov_idx = 0;
+	struct kvec iov_buf[3], iovs;
 
 	if (!work->response_buf) {
 		pr_err("NULL response header\n");
 		return -EINVAL;
 	}
 
-	if (work->tr_buf) {
-		iov[iov_idx] = (struct kvec) { work->tr_buf,
-				sizeof(struct smb2_transform_hdr) + 4 };
-		len += iov[iov_idx++].iov_len;
-	}
+	len = smb_generate_rsp_ivs(work, iov_buf, 3, &iovs, true);
+	if (len < 0)
+		return (int)len;
 
-	if (work->aux_payload_sz) {
-		iov[iov_idx] = (struct kvec) { work->response_buf, work->resp_hdr_sz };
-		len += iov[iov_idx++].iov_len;
-		iov[iov_idx] = (struct kvec) { work->aux_payload_buf, work->aux_payload_sz };
-		len += iov[iov_idx++].iov_len;
-	} else {
-		if (work->tr_buf)
-			iov[iov_idx].iov_len = work->resp_hdr_sz;
-		else
-			iov[iov_idx].iov_len = get_rfc1002_len(work->response_buf) + 4;
-		iov[iov_idx].iov_base = work->response_buf;
-		len += iov[iov_idx++].iov_len;
-	}
 
 	ksmbd_conn_lock(conn);
-	sent = conn->transport->ops->writev(conn->transport, &iov[0],
-					iov_idx, len,
-					work->need_invalidate_rkey,
-					work->remote_key);
+	sent = conn->transport->ops->writev(conn->transport,
+			(struct kvec *)iovs.iov_base,
+			(int)iovs.iov_len, len,
+			work->need_invalidate_rkey,
+			work->remote_key);
 	ksmbd_conn_unlock(conn);
+	if (iovs.iov_base != iov_buf)
+		kvfree(iovs.iov_base);
 
 	if (sent < 0) {
 		pr_err("Failed to send message: %d\n", sent);

--- a/ksmbd_work.c
+++ b/ksmbd_work.c
@@ -27,16 +27,23 @@ struct ksmbd_work *ksmbd_alloc_work_struct(void)
 		INIT_LIST_HEAD(&work->async_request_entry);
 		INIT_LIST_HEAD(&work->fp_entry);
 		INIT_LIST_HEAD(&work->interim_entry);
+		INIT_LIST_HEAD(&work->aux_payload_list);
 	}
 	return work;
 }
 
 void ksmbd_free_work_struct(struct ksmbd_work *work)
 {
+	struct ksmbd_aux_payload *aux, *tmp_aux;
+
 	WARN_ON(work->saved_cred != NULL);
 
+	list_for_each_entry_safe(aux, tmp_aux, &work->aux_payload_list, entry) {
+		list_del_init(&aux->entry);
+		kvfree(aux);
+	}
+
 	kvfree(work->response_buf);
-	kvfree(work->aux_payload_buf);
 	kfree(work->tr_buf);
 	kvfree(work->request_buf);
 	if (work->async_id)

--- a/ksmbd_work.h
+++ b/ksmbd_work.h
@@ -19,6 +19,14 @@ enum {
 	KSMBD_WORK_CLOSED,
 };
 
+struct ksmbd_aux_payload {
+	struct   list_head entry; /* Link to work's response_list */
+
+	int      insert_pos;    /* Meaning similar to next_smb2_rsp_hdr_off */
+	size_t   len;
+	char     base[];
+};
+
 /* one of these for every pending CIFS request at the connection */
 struct ksmbd_work {
 	/* Server corresponding to this mid */
@@ -31,8 +39,8 @@ struct ksmbd_work {
 	/* Response buffer */
 	void                            *response_buf;
 
-	/* Read data buffer */
-	void                            *aux_payload_buf;
+	/* a list of read data buffer */
+	struct list_head                aux_payload_list; //a list of ITSmb_aux_payload_vec
 
 	/* Next cmd hdr in compound req buf*/
 	int                             next_smb2_rcv_hdr_off;
@@ -52,11 +60,8 @@ struct ksmbd_work {
 	/* Number of granted credits */
 	unsigned int			credits_granted;
 
-	/* response smb header size */
-	unsigned int                    resp_hdr_sz;
-	unsigned int                    response_sz;
-	/* Read data count */
-	unsigned int                    aux_payload_sz;
+    /* response buffer allocated size */
+	unsigned int            response_sz;
 
 	void				*tr_buf;
 

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -30,7 +30,7 @@
 #include "ndr.h"
 #include "smberr.h"
 
-static int smb1_oplock_enable = false;
+static int smb1_oplock_enable;
 
 /* Default: allocation roundup size = 1048576 */
 static unsigned int alloc_roundup_size = 1048576;
@@ -986,7 +986,7 @@ no_password_check:
 	/* 1 byte padding for word alignment */
 	offset = 1;
 
-	memset(str, 0 , sizeof(str));
+	memset(str, 0, sizeof(str));
 
 	len = smb_strtoUTF16(str, "Unix", 4, conn->local_nls);
 	len = UNICODE_LEN(len + 1);
@@ -2863,6 +2863,7 @@ int smb_read_andx(struct ksmbd_work *work)
 	size_t count;
 	ssize_t nbytes;
 	int err = 0;
+	struct ksmbd_aux_payload *aux_payload = NULL;
 
 	if (test_share_config_flag(work->tcon->share_conf,
 				   KSMBD_SHARE_FLAG_PIPE))
@@ -2907,19 +2908,20 @@ int smb_read_andx(struct ksmbd_work *work)
 	ksmbd_debug(SMB, "filename %pd, offset %lld, count %zu\n",
 		    fp->filp->f_path.dentry, pos, count);
 
-	work->aux_payload_buf = kvmalloc(count, GFP_KERNEL | __GFP_ZERO);
-	if (!work->aux_payload_buf) {
+	aux_payload = kvmalloc(sizeof(struct ksmbd_aux_payload)+count, GFP_KERNEL | __GFP_ZERO);
+	if (!aux_payload) {
 		err = -ENOMEM;
 		goto out;
 	}
-
-	nbytes = ksmbd_vfs_read(work, fp, count, &pos);
+	aux_payload->len = count;
+	nbytes = ksmbd_vfs_read(work, fp, aux_payload, count, &pos);
 	if (nbytes < 0) {
 		err = nbytes;
+		kvfree(aux_payload);
 		goto out;
 	}
 
-	/* read success, prepare response */
+    /* read success, prepare response */
 	rsp->hdr.Status.CifsError = STATUS_SUCCESS;
 	rsp->hdr.WordCount = 12;
 	rsp->Remaining = 0;
@@ -2934,8 +2936,10 @@ int smb_read_andx(struct ksmbd_work *work)
 
 	rsp->ByteCount = cpu_to_le16(nbytes);
 	inc_rfc1001_len(&rsp->hdr, (rsp->hdr.WordCount * 2));
-	work->resp_hdr_sz = get_rfc1002_len(rsp) + 4;
-	work->aux_payload_sz = nbytes;
+	aux_payload->len = nbytes;
+	aux_payload->insert_pos = get_rfc1002_len(work->response_buf) -
+		ksmbd_sum_aux_payload_size(work);
+	list_add_tail(&aux_payload->entry, &work->aux_payload_list);
 	inc_rfc1001_len(&rsp->hdr, nbytes);
 
 	/* this is an ANDx command ? */
@@ -8483,29 +8487,24 @@ void smb1_set_sign_rsp(struct ksmbd_work *work)
 {
 	struct smb_hdr *rsp_hdr = (struct smb_hdr *)work->response_buf;
 	char signature[20];
-	struct kvec iov[2];
-	int n_vec = 1;
+	struct kvec iov_buf[2], iovs;
 
 	rsp_hdr->Flags2 |= SMBFLG2_SECURITY_SIGNATURE;
 	rsp_hdr->Signature.Sequence.SequenceNumber =
 		cpu_to_le32(++work->sess->sequence_number);
 	rsp_hdr->Signature.Sequence.Reserved = 0;
 
-	iov[0].iov_base = rsp_hdr->Protocol;
-	iov[0].iov_len = be32_to_cpu(rsp_hdr->smb_buf_length);
+	if (smb_generate_rsp_ivs(work, iov_buf, 2, &iovs, false) < 0)
+		return;
 
-	if (work->aux_payload_sz) {
-		iov[0].iov_len -= work->aux_payload_sz;
-
-		iov[1].iov_base = work->aux_payload_buf;
-		iov[1].iov_len = work->aux_payload_sz;
-		n_vec++;
-	}
-
-	if (ksmbd_sign_smb1_pdu(work->sess, iov, n_vec, signature))
+	if (ksmbd_sign_smb1_pdu(work->sess, (struct kvec *)iovs.iov_base,
+				(int)iovs.iov_len, signature))
 		memset(rsp_hdr->Signature.SecuritySignature,
 				0, CIFS_SMB1_SIGNATURE_SIZE);
 	else
 		memcpy(rsp_hdr->Signature.SecuritySignature,
 				signature, CIFS_SMB1_SIGNATURE_SIZE);
+
+	if (iovs.iov_base != iov_buf)
+		kvfree(iovs.iov_base);
 }

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -1649,7 +1649,8 @@ u16 get_smb2_cmd_val(struct ksmbd_work *work);
 void set_smb2_rsp_status(struct ksmbd_work *work, __le32 err);
 int init_smb2_rsp_hdr(struct ksmbd_work *work);
 int smb2_allocate_rsp_buf(struct ksmbd_work *work);
-bool is_chained_smb2_message(struct ksmbd_work *work);
+int smb2_seal_rsp(struct ksmbd_work *work);
+void init_chained_smb2_rsp(struct ksmbd_work *work, int next_rsp_hdr_off);
 int init_smb2_neg_rsp(struct ksmbd_work *work);
 void smb2_set_err_rsp(struct ksmbd_work *work);
 int smb2_check_user_session(struct ksmbd_work *work);
@@ -1674,6 +1675,9 @@ int smb3_encrypt_resp(struct ksmbd_work *work);
 bool smb3_11_final_sess_setup_resp(struct ksmbd_work *work);
 int smb2_set_rsp_credits(struct ksmbd_work *work);
 bool smb3_encryption_negotiated(struct ksmbd_conn *conn);
+struct kvec;
+int smb_generate_rsp_ivs(struct ksmbd_work *work, struct kvec *iov_buf,
+			 int iov_buf_count, struct kvec *result, bool whole);
 
 /* smb2 misc functions */
 int ksmbd_smb2_check_message(struct ksmbd_work *work);

--- a/smb_common.c
+++ b/smb_common.c
@@ -660,6 +660,21 @@ int ksmbd_smb_check_shared_mode(struct file *filp, struct ksmbd_file *curr_fp)
 	return rc;
 }
 
+/**
+ * ksmbd_sum_aux_payload_size() - handler for sum up all aux payload.
+ * @work:           smb work containing response payload buffer
+ */
+int ksmbd_sum_aux_payload_size(struct ksmbd_work *work)
+{
+	int len = 0;
+	struct ksmbd_aux_payload *aux;
+
+	list_for_each_entry(aux, &work->aux_payload_list, entry) {
+		len += aux->len;
+	}
+	return len;
+}
+
 bool is_asterisk(char *p)
 {
 	return p && p[0] == '*';

--- a/smb_common.h
+++ b/smb_common.h
@@ -511,6 +511,7 @@ int ksmbd_extract_shortname(struct ksmbd_conn *conn,
 			    char *shortname);
 
 int ksmbd_smb_negotiate_common(struct ksmbd_work *work, unsigned int command);
+int ksmbd_sum_aux_payload_size(struct ksmbd_work *work);
 
 int ksmbd_smb_check_shared_mode(struct file *filp, struct ksmbd_file *curr_fp);
 int ksmbd_override_fsids(struct ksmbd_work *work);

--- a/vfs.c
+++ b/vfs.c
@@ -400,18 +400,29 @@ out:
  * ksmbd_vfs_read() - vfs helper for smb file read
  * @work:	smb work
  * @fid:	file id of open file
+ * @aux_payload: read payload buffer
  * @count:	read byte count
  * @pos:	file pos
  *
  * Return:	number of read bytes on success, otherwise error
  */
-int ksmbd_vfs_read(struct ksmbd_work *work, struct ksmbd_file *fp, size_t count,
-		   loff_t *pos)
+int ksmbd_vfs_read(struct ksmbd_work *work, struct ksmbd_file *fp,
+					struct ksmbd_aux_payload *aux_payload, size_t count,
+					loff_t *pos)
 {
 	struct file *filp = fp->filp;
 	ssize_t nbytes = 0;
-	char *rbuf = work->aux_payload_buf;
-	struct inode *inode = file_inode(filp);
+	char *rbuf;
+	struct inode *inode;
+
+	if (!aux_payload)
+		return -EINVAL;
+	if (count > aux_payload->len)
+		return -ENOSPC;
+
+	rbuf = aux_payload->base;
+
+	inode = file_inode(filp);
 
 	if (S_ISDIR(inode->i_mode))
 		return -EISDIR;

--- a/vfs.h
+++ b/vfs.h
@@ -132,8 +132,10 @@ int ksmbd_vfs_query_maximal_access(struct user_namespace *user_ns,
 				   struct dentry *dentry, __le32 *daccess);
 int ksmbd_vfs_create(struct ksmbd_work *work, const char *name, umode_t mode);
 int ksmbd_vfs_mkdir(struct ksmbd_work *work, const char *name, umode_t mode);
+struct ksmbd_aux_payload;
 int ksmbd_vfs_read(struct ksmbd_work *work, struct ksmbd_file *fp,
-		   size_t count, loff_t *pos);
+		   struct ksmbd_aux_payload *aux_payload, size_t count,
+		   loff_t *pos);
 int ksmbd_vfs_write(struct ksmbd_work *work, struct ksmbd_file *fp,
 		    char *buf, size_t count, loff_t *pos, bool sync,
 		    ssize_t *written);


### PR DESCRIPTION
While ksmbd received a compounded request, needs concatenate all responses for all commands in the request. There may be contains multi read commands. Previously only one aux_payload_buf for one read command, so can't reply correct for compounded request which contains multi read commands, especially when the read command in the middle of the chain.