### PR TITLE
ksmbd: smb1: fix null dereference in smb_session_disconnect

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -319,9 +319,6 @@ int smb_session_disconnect(struct ksmbd_work *work)
 	/* setting CifsExiting here may race with start_tcp_sess */
 	ksmbd_conn_set_need_reconnect(work);
 
-	ksmbd_free_user(sess->user);
-	sess->user = NULL;
-
 	ksmbd_conn_wait_idle(conn);
 
 	ksmbd_tree_conn_session_logoff(sess);


### PR DESCRIPTION
smb_session_disconnect() calls ksmbd_session_destroy() which checks for null before freeing the user, so remove the call.

The null-deref can be triggered by a client sending a Session Setup request with a NtLmNegotiate payload (therefore allocating and registering a session) followed by a Session Disconnect request. Because users are allocated on NtLmAuthenticate, sess->user is null.