### PR TITLE
linux 6.12: move asm/unaligned.h to linux/unaligned.h

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -8,7 +8,11 @@
  */
 #include <linux/fs.h>
 #include <linux/slab.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
 #include "glob.h"
 #include "unicode.h"
 #include "uniupr.h"

--- a/unicode.c
+++ b/unicode.c
@@ -8,6 +8,7 @@
  */
 #include <linux/fs.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
 #include <linux/unaligned.h>
 #else


### PR DESCRIPTION
> asm/unaligned.h is always an include of asm-generic/unaligned.h;
> might as well move that thing to linux/unaligned.h and include
> that - there's nothing arch-specific in that header.
> 
> author | Al Viro <viro@zeniv.linux.org.uk> | 2024-10-01 15:35:57 -0400


P.S: Thanks so much for ksmbd! xfer/iops performance gains since moving away from samba is amazing.

Jon