### PR TITLE
Various SMB1 fixes

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -1273,8 +1273,9 @@ no_password_check:
 			rsp->ByteCount = rsp->SecurityBlobLength;
 		}
 	} else {
-		pr_err("Invalid phase\n");
+		pr_err("Invalid phase %d\n", negblob->MessageType);
 		err = -EINVAL;
+		goto out_err;
 	}
 
 	/* this is an ANDx command ? */

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -1371,6 +1371,7 @@ out_err:
 	rsp->resp.ByteCount = 0;
 	if (rc < 0 && sess) {
 		xa_erase(&conn->sessions, sess->id);
+		hash_del(&sess->hlist);
 		ksmbd_session_destroy(sess);
 		work->sess = NULL;
 	}

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -336,8 +336,10 @@ int smb_check_user_session(struct ksmbd_work *work)
 	}
 
 	work->sess = ksmbd_session_lookup(conn, le16_to_cpu(req_hdr->Uid));
-	if (work->sess)
+	if (work->sess) {
+		ksmbd_user_session_get(work->sess);
 		return 1;
+	}
 	ksmbd_debug(SMB, "Invalid user session, Uid %u\n",
 		    le16_to_cpu(req_hdr->Uid));
 	return -EINVAL;
@@ -1333,6 +1335,7 @@ int smb_session_setup_andx(struct ksmbd_work *work)
 			rc = -ENOENT;
 			goto out_err;
 		}
+		ksmbd_user_session_get(sess);
 		ksmbd_debug(SMB, "Reuse session ID: %llu, Uid: %u\n",
 			    sess->id, uid);
 	} else {

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -884,6 +884,7 @@ int smb_rename(struct ksmbd_work *work)
 		goto out;
 	}
 
+	ksmbd_update_fstate(&work->sess->file_table, fp, FP_INITED);
 	rc = ksmbd_vfs_fp_rename(work, fp, newname);
 	if (rc) {
 		rsp->hdr.Status.CifsError = STATUS_NO_MEMORY;
@@ -5190,6 +5191,7 @@ free_path:
 out:
 	switch (err) {
 	case 0:
+		ksmbd_update_fstate(&work->sess->file_table, fp, FP_INITED);
 		break;
 	case -ENOSPC:
 		pSMB_rsp->hdr.Status.CifsError = STATUS_DISK_FULL;


### PR DESCRIPTION
While checking the latest ksmbd patches, I noticed I have some local SMB1 specific changes that I forgot to upstream:

* ksmbd: smb1: fix out-of-bounds write in smb_read_andx_pipe
* ksmbd: smb1: add missing hash_del when destroying session
* ksmbd: smb1: handle unknown NTLM message as an error
* ksmbd: smb1: add missing ksmbd_update_fstate calls
* ksmbd: smb1: increment session refcnt

The first two fix memory corruptions. The third is more of logic error in that the server does not send an error back to the client. The last result in resource leaks.