### PR TITLE
ksmb: Fix length calculating bug in Negotiation phase 

### DIFF
--- a/smb_common.c
+++ b/smb_common.c
@@ -306,7 +306,7 @@ static int ksmbd_negotiate_smb_dialect(void *buf)
 		if (smb2_neg_size > smb_buf_length)
 			goto err_out;
 
-		if (struct_size(req, Dialects, le16_to_cpu(req->DialectCount)) >
+		if (struct_size(req, Dialects, le16_to_cpu(req->DialectCount)) - sizeof(req->Dialects) >
 		    smb_buf_length)
 			goto err_out;
 


### PR DESCRIPTION
in smb_common.c, the

struct smb2_negotiate_req {
	struct smb2_sync_hdr sync_hdr;
	__le16 StructureSize; /* Must be 36 */
	__le16 DialectCount;
	__le16 SecurityMode;
	__le16 Reserved;	/* MBZ */
	__le32 Capabilities;
	__u8   ClientGUID[SMB2_CLIENT_GUID_SIZE];
	/* In SMB3.02 and earlier next three were MBZ le64 ClientStartTime */
	__le32 NegotiateContextOffset; /* SMB3.1.1 only. MBZ earlier */
	__le16 NegotiateContextCount;  /* SMB3.1.1 only. MBZ earlier */
	__le16 Reserved2;
	__le16 Dialects[4]; /* BB expand this if autonegotiate > 4 dialects */
} __packed;

contains a  Dialects array element which leads to wrong size calculating in ksmbd_negotiate_smb_dialect  further leading to negotiating failure. Maybe should amend this structure  or modify the codtition expression?