### PR TITLE
fix smb1 oob read

### DIFF
--- a/smb1pdu.h
+++ b/smb1pdu.h
@@ -460,7 +460,7 @@ struct smb_com_lock_req {
 	__le16 NumberOfUnlocks;
 	__le16 NumberOfLocks;
 	__le16 ByteCount;
-	char *Locks[1];
+	char Locks[1];
 } __packed;
 
 struct smb_com_lock_rsp {


### PR DESCRIPTION
fix out-of-bounds read in smb_locking_andx()

The Locks field in struct smb_com_lock_req is declared as an array of pointers (`char *Locks[1]`), which gives it type `char **`.  
This causes pointer arithmetic on req->Locks to scale by sizeof(char *) (8 bytes on 64-bit) instead of by 1 byte.  

In smb_locking_andx(), the code computes unlock element pointers as:
```req->Locks + (sizeof(struct locking_andx_range64) * lock_count)```
With the current `char **` type, this advances by 8x the intended offset, reading far beyond the request buffer into adjacent kernel memory.  

Fix by declaring Locks as `char Locks[1]` so that pointer arithmetic operates at byte granularity, matching the intended behavior.