### PR TITLE
ksmbd: Time Machine / Apple AAPL support, plus several standalone fixes found along the way

### DIFF
--- a/connection.h
+++ b/connection.h
@@ -116,6 +116,7 @@ struct ksmbd_conn {
 	bool				binding;
 	atomic_t			refcnt;
 	bool				is_aapl;
+	bool				aapl_readdir_attr; /* READDIR_ATTR negotiated */
 };
 
 struct ksmbd_conn_ops {

--- a/ksmbd_netlink.h
+++ b/ksmbd_netlink.h
@@ -113,7 +113,8 @@ struct ksmbd_startup_request {
 	__u32	max_connections;	/* Number of maximum simultaneous connections */
 	__s8	bind_interfaces_only;
 	__u32	max_ip_connections;	/* Number of maximum connection per ip address */
-	__s8	reserved[499];		/* Reserved room */
+	__s8	aapl_model[32];		/* AAPL model string for Finder icon, e.g. "Xserve" */
+	__s8	reserved[467];		/* Reserved room */
 	__u32	ifc_list_sz;		/* interfaces list size */
 	__s8	____payload[];
 } __packed;
@@ -377,6 +378,7 @@ enum KSMBD_TREE_CONN_STATUS {
 #define KSMBD_SHARE_FLAG_UPDATE				BIT(14)
 #define KSMBD_SHARE_FLAG_CROSSMNT			BIT(15)
 #define KSMBD_SHARE_FLAG_CONTINUOUS_AVAILABILITY	BIT(16)
+#define KSMBD_SHARE_FLAG_TIME_MACHINE			BIT(17)
 
 /*
  * Tree connect request flags.

--- a/ksmbd_work.c
+++ b/ksmbd_work.c
@@ -26,6 +26,7 @@ struct ksmbd_work *ksmbd_alloc_work_struct(void)
 		INIT_LIST_HEAD(&work->request_entry);
 		INIT_LIST_HEAD(&work->async_request_entry);
 		INIT_LIST_HEAD(&work->fp_entry);
+		INIT_LIST_HEAD(&work->notify_entry);
 		INIT_LIST_HEAD(&work->aux_read_list);
 		work->iov_alloc_cnt = 4;
 		work->iov = kzalloc(sizeof(struct kvec) * work->iov_alloc_cnt,

--- a/ksmbd_work.h
+++ b/ksmbd_work.h
@@ -89,6 +89,8 @@ struct ksmbd_work {
 	/* List head at conn->async_requests */
 	struct list_head                async_request_entry;
 	struct list_head                fp_entry;
+	/* List head at ksmbd_file->notify_pendings */
+	struct list_head                notify_entry;
 
 #ifdef CONFIG_SMB_INSECURE_SERVER
 	/* Read data buffer */

--- a/mgmt/user_session.c
+++ b/mgmt/user_session.c
@@ -86,6 +86,9 @@ static int __rpc_method(char *rpc_name)
 	if (!strcmp(rpc_name, "\\lsarpc") || !strcmp(rpc_name, "lsarpc"))
 		return KSMBD_RPC_LSARPC_METHOD_INVOKE;
 
+	if (!strcmp(rpc_name, "\\mdssvc") || !strcmp(rpc_name, "mdssvc"))
+		return 0; /* mdssvc disabled: NOT_FOUND so macOS falls back */
+
 	pr_err("Unsupported RPC: %s\n", rpc_name);
 	return 0;
 }

--- a/oplock.c
+++ b/oplock.c
@@ -1295,11 +1295,66 @@ static void set_oplock_level(struct oplock_info *opinfo, int level,
 	}
 }
 
+/*
+ * Collect refcounted lease holders on a parent directory that need to be
+ * broken, without holding p_ci->m_lock during the break acknowledgment
+ * wait (up to OPLOCK_WAIT_TIME, 35s). Holding that lock across
+ * oplock_break() blocks every other create/delete/rename under the same
+ * parent directory for the full wait whenever a single lease holder
+ * fails to acknowledge -- e.g. a macOS Time Machine client whose backupd
+ * connection has gone quiet mid-backup while Finder is still browsing
+ * the same share. Returns the number of entries filled into *out
+ * (caller must kfree it).
+ */
+static int collect_parent_lease_holders(struct ksmbd_inode *p_ci,
+					struct ksmbd_file *fp,
+					struct lease_ctx_info *lctx,
+					struct oplock_info ***out)
+{
+	struct oplock_info *opinfo, **arr = NULL;
+	int count = 0, cap = 0;
+
+	down_read(&p_ci->m_lock);
+	list_for_each_entry(opinfo, &p_ci->m_op_list, op_entry) {
+		if (opinfo->conn == NULL || !opinfo->is_lease)
+			continue;
+		if (opinfo->o_lease->state == SMB2_OPLOCK_LEVEL_NONE)
+			continue;
+		if (lctx && (lctx->flags & SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET_LE) &&
+		    compare_guid_key(opinfo, fp->conn->ClientGUID,
+				     lctx->parent_lease_key))
+			continue;
+		if (!atomic_inc_not_zero(&opinfo->refcount))
+			continue;
+		if (ksmbd_conn_releasing(opinfo->conn)) {
+			opinfo_put(opinfo);
+			continue;
+		}
+		if (count == cap) {
+			int new_cap = cap ? cap * 2 : 4;
+			struct oplock_info **n = krealloc(arr,
+					new_cap * sizeof(*n), GFP_KERNEL);
+			if (!n) {
+				opinfo_put(opinfo);
+				continue;
+			}
+			arr = n;
+			cap = new_cap;
+		}
+		arr[count++] = opinfo;
+	}
+	up_read(&p_ci->m_lock);
+
+	*out = arr;
+	return count;
+}
+
 void smb_send_parent_lease_break_noti(struct ksmbd_file *fp,
 				      struct lease_ctx_info *lctx)
 {
-	struct oplock_info *opinfo;
 	struct ksmbd_inode *p_ci = NULL;
+	struct oplock_info **to_break = NULL;
+	int count, i;
 
 	if (lctx->version != 2)
 		return;
@@ -1308,36 +1363,22 @@ void smb_send_parent_lease_break_noti(struct ksmbd_file *fp,
 	if (!p_ci)
 		return;
 
-	down_read(&p_ci->m_lock);
-	list_for_each_entry(opinfo, &p_ci->m_op_list, op_entry) {
-		if (opinfo->conn == NULL || !opinfo->is_lease)
-			continue;
-
-		if (opinfo->o_lease->state != SMB2_OPLOCK_LEVEL_NONE &&
-		    (!(lctx->flags & SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET_LE) ||
-		     !compare_guid_key(opinfo, fp->conn->ClientGUID,
-				      lctx->parent_lease_key))) {
-			if (!atomic_inc_not_zero(&opinfo->refcount))
-				continue;
-
-			if (ksmbd_conn_releasing(opinfo->conn)) {
-				opinfo_put(opinfo);
-				continue;
-			}
-
-			oplock_break(opinfo, SMB2_OPLOCK_LEVEL_NONE, NULL);
-			opinfo_put(opinfo);
-		}
-	}
-	up_read(&p_ci->m_lock);
-
+	count = collect_parent_lease_holders(p_ci, fp, lctx, &to_break);
 	ksmbd_inode_put(p_ci);
+
+	for (i = 0; i < count; i++) {
+		oplock_break(to_break[i], SMB2_OPLOCK_LEVEL_NONE, NULL);
+		opinfo_put(to_break[i]);
+	}
+	kfree(to_break);
 }
 
 void smb_lazy_parent_lease_break_close(struct ksmbd_file *fp)
 {
 	struct oplock_info *opinfo;
 	struct ksmbd_inode *p_ci = NULL;
+	struct oplock_info **to_break = NULL;
+	int count, i;
 
 	rcu_read_lock();
 	opinfo = rcu_dereference(fp->f_opinfo);
@@ -1350,27 +1391,14 @@ void smb_lazy_parent_lease_break_close(struct ksmbd_file *fp)
 	if (!p_ci)
 		return;
 
-	down_read(&p_ci->m_lock);
-	list_for_each_entry(opinfo, &p_ci->m_op_list, op_entry) {
-		if (opinfo->conn == NULL || !opinfo->is_lease)
-			continue;
-
-		if (opinfo->o_lease->state != SMB2_OPLOCK_LEVEL_NONE) {
-			if (!atomic_inc_not_zero(&opinfo->refcount))
-				continue;
-
-			if (ksmbd_conn_releasing(opinfo->conn)) {
-				opinfo_put(opinfo);
-				continue;
-			}
-
-			oplock_break(opinfo, SMB2_OPLOCK_LEVEL_NONE, NULL);
-			opinfo_put(opinfo);
-		}
-	}
-	up_read(&p_ci->m_lock);
-
+	count = collect_parent_lease_holders(p_ci, fp, NULL, &to_break);
 	ksmbd_inode_put(p_ci);
+
+	for (i = 0; i < count; i++) {
+		oplock_break(to_break[i], SMB2_OPLOCK_LEVEL_NONE, NULL);
+		opinfo_put(to_break[i]);
+	}
+	kfree(to_break);
 }
 
 /**

--- a/oplock.c
+++ b/oplock.c
@@ -18,6 +18,7 @@
 #include "mgmt/user_session.h"
 #include "mgmt/share_config.h"
 #include "mgmt/tree_connect.h"
+#include "server.h"
 
 static LIST_HEAD(lease_table_list);
 static DEFINE_RWLOCK(lease_list_lock);
@@ -2049,6 +2050,78 @@ void create_posix_rsp_buf(char *cc, struct ksmbd_file *fp)
 	id_to_sid(from_kgid_munged(&init_user_ns, inode->i_gid),
 #endif
 		  SIDUNIX_GROUP, (struct smb_sid *)&buf->SidBuffer[28]);
+}
+
+/**
+ * create_aapl_rsp_buf() - build Apple AAPL kAAPL_SERVER_QUERY response
+ * @cc:         buffer to write the create context into (AAPL_RSP_MAX_SIZE bytes)
+ * @vol_caps:   volume capability flags (AAPL_VOLCAPS_*)
+ * @req_bitmap: the client's request bitmap, echoed back in reply_bitmap
+ *
+ * Response format follows the layout observed from macOS's own smbd:
+ *   reply_bitmap = req_bitmap masked to the fields we support
+ *   server_caps  = AAPL_SERVER_CAPS_KSMBD when requested
+ *   vol_caps     = caller-supplied
+ *   model string = server_conf.aapl_model (default "Xserve") in UTF-16LE,
+ *                  when AAPL_BITMAP_MODEL_INFO requested
+ *
+ * Sending reply_bitmap=0x03 without a model string causes smbfs.kext to
+ * enter a broken disconnect path requiring a macOS reboot to recover.
+ */
+void create_aapl_rsp_buf(char *cc, __u64 vol_caps, __u64 req_bitmap)
+{
+	struct create_aapl_rsp *buf;
+	u64 reply_bitmap;
+	u32 data_len;
+
+	buf = (struct create_aapl_rsp *)cc;
+	memset(buf, 0, AAPL_RSP_MAX_SIZE);
+
+	reply_bitmap = req_bitmap & (AAPL_BITMAP_SERVER_CAPS |
+				     AAPL_BITMAP_VOL_CAPS |
+				     AAPL_BITMAP_MODEL_INFO);
+
+	/* base data: cmd(4)+reserved(4)+reply_bitmap(8)+server_caps(8)+vol_caps(8) */
+	data_len = 32;
+	if (reply_bitmap & AAPL_BITMAP_MODEL_INFO)
+		data_len += 4 + 4 + AAPL_MODEL_UTF16_BYTES; /* pad2+model_bytes+string */
+
+	buf->ccontext.DataOffset = cpu_to_le16(offsetof(struct create_aapl_rsp, cmd));
+	buf->ccontext.DataLength = cpu_to_le32(data_len);
+	buf->ccontext.NameOffset = cpu_to_le16(offsetof(struct create_aapl_rsp, Name));
+	buf->ccontext.NameLength = cpu_to_le16(4);
+	buf->Name[0] = 'A';
+	buf->Name[1] = 'A';
+	buf->Name[2] = 'P';
+	buf->Name[3] = 'L';
+
+	buf->cmd = cpu_to_le32(AAPL_SERVER_QUERY);
+	buf->reply_bitmap = cpu_to_le64(reply_bitmap);
+	buf->server_caps = (reply_bitmap & AAPL_BITMAP_SERVER_CAPS) ?
+			   cpu_to_le64(AAPL_SERVER_CAPS_KSMBD) : 0;
+	buf->vol_caps = (reply_bitmap & AAPL_BITMAP_VOL_CAPS) ?
+			cpu_to_le64(vol_caps) : 0;
+
+	if (reply_bitmap & AAPL_BITMAP_MODEL_INFO) {
+		__le32 *p = (__le32 *)((u8 *)buf + sizeof(*buf));
+		__le16 *model_str = (__le16 *)(p + 2);
+		const char *src = server_conf.aapl_model[0] ?
+				  server_conf.aapl_model : "Xserve";
+		int i, model_bytes = 0;
+
+		/* Convert ASCII model string to UTF-16LE in-place */
+		for (i = 0; src[i] && i < AAPL_MODEL_MAX_CHARS; i++) {
+			model_str[i] = cpu_to_le16((unsigned char)src[i]);
+			model_bytes += 2;
+		}
+
+		p[0] = 0; /* pad2 */
+		p[1] = cpu_to_le32(model_bytes);
+
+		/* Update DataLength to reflect actual model string size */
+		buf->ccontext.DataLength =
+			cpu_to_le32(data_len - AAPL_MODEL_UTF16_BYTES + model_bytes);
+	}
 }
 
 /*

--- a/oplock.h
+++ b/oplock.h
@@ -123,6 +123,7 @@ void create_durable_v2_rsp_buf(char *cc, struct ksmbd_file *fp);
 void create_mxac_rsp_buf(char *cc, int maximal_access);
 void create_disk_id_rsp_buf(char *cc, __u64 file_id, __u64 vol_id);
 void create_posix_rsp_buf(char *cc, struct ksmbd_file *fp);
+void create_aapl_rsp_buf(char *cc, __u64 vol_caps, __u64 req_bitmap);
 struct create_context *smb2_find_context_vals(void *open_req, const char *tag, int tag_len);
 struct oplock_info *lookup_lease_in_table(struct ksmbd_conn *conn,
 					  char *lease_key);

--- a/server.h
+++ b/server.h
@@ -48,6 +48,8 @@ struct ksmbd_server_config {
 	char			*conf[SERVER_CONF_WORK_GROUP + 1];
 	struct task_struct	*dh_task;
 	bool			bind_interfaces_only;
+	/* AAPL model string for Finder icon, e.g. "Xserve" */
+	char			aapl_model[32];
 };
 
 extern struct ksmbd_server_config server_conf;

--- a/smb2ops.c
+++ b/smb2ops.c
@@ -38,6 +38,7 @@ static struct smb_version_values smb20_server_values = {
 	.create_mxac_size = sizeof(struct create_mxac_rsp),
 	.create_disk_id_size = sizeof(struct create_disk_id_rsp),
 	.create_posix_size = sizeof(struct create_posix_rsp),
+	.create_aapl_size = AAPL_RSP_MAX_SIZE,
 };
 #endif
 
@@ -65,6 +66,7 @@ static struct smb_version_values smb21_server_values = {
 	.create_mxac_size = sizeof(struct create_mxac_rsp),
 	.create_disk_id_size = sizeof(struct create_disk_id_rsp),
 	.create_posix_size = sizeof(struct create_posix_rsp),
+	.create_aapl_size = AAPL_RSP_MAX_SIZE,
 };
 
 static struct smb_version_values smb30_server_values = {
@@ -92,6 +94,7 @@ static struct smb_version_values smb30_server_values = {
 	.create_mxac_size = sizeof(struct create_mxac_rsp),
 	.create_disk_id_size = sizeof(struct create_disk_id_rsp),
 	.create_posix_size = sizeof(struct create_posix_rsp),
+	.create_aapl_size = AAPL_RSP_MAX_SIZE,
 };
 
 static struct smb_version_values smb302_server_values = {
@@ -119,6 +122,7 @@ static struct smb_version_values smb302_server_values = {
 	.create_mxac_size = sizeof(struct create_mxac_rsp),
 	.create_disk_id_size = sizeof(struct create_disk_id_rsp),
 	.create_posix_size = sizeof(struct create_posix_rsp),
+	.create_aapl_size = AAPL_RSP_MAX_SIZE,
 };
 
 static struct smb_version_values smb311_server_values = {
@@ -146,6 +150,7 @@ static struct smb_version_values smb311_server_values = {
 	.create_mxac_size = sizeof(struct create_mxac_rsp),
 	.create_disk_id_size = sizeof(struct create_disk_id_rsp),
 	.create_posix_size = sizeof(struct create_posix_rsp),
+	.create_aapl_size = AAPL_RSP_MAX_SIZE,
 };
 
 static struct smb_version_ops smb2_0_server_ops = {

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2347,7 +2347,13 @@ static noinline int create_smb2_pipe(struct ksmbd_work *work)
 out:
 	switch (err) {
 	case -EINVAL:
-		rsp->hdr.Status = STATUS_INVALID_PARAMETER;
+		/*
+		 * Unknown pipe name: return STATUS_OBJECT_NAME_NOT_FOUND so
+		 * macOS clients skip it gracefully. STATUS_INVALID_PARAMETER
+		 * causes macOS Time Machine to abort the backup immediately
+		 * (confirmed in ksmbd issue #502 / namjaejeon/ksmbd).
+		 */
+		rsp->hdr.Status = STATUS_OBJECT_NAME_NOT_FOUND;
 		break;
 	case -ENOSPC:
 	case -ENOMEM:

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -8467,23 +8467,33 @@ static int fsctl_copychunk(struct ksmbd_work *work,
 
 	chunks = (struct srv_copychunk *)&ci_req->Chunks[0];
 	chunk_count = le32_to_cpu(ci_req->ChunkCount);
-	if (chunk_count == 0)
+	/*
+	 * ChunkCount=0 is the standard SMB2 "query my copy limits" request
+	 * (no data copied) -- but macOS Finder's Cmd+D duplicate sends
+	 * FSCTL_SRV_COPYCHUNK with ChunkCount=0 meaning "copy the whole
+	 * file", relying on the AAPL-negotiated server to do a full copy
+	 * instead. Keep the standard no-op behavior for everyone else.
+	 */
+	if (chunk_count == 0 && !work->conn->is_aapl)
 		goto out;
 	total_size_written = 0;
+	i = 0;
 
-	/* verify the SRV_COPYCHUNK_COPY packet */
-	if (chunk_count > ksmbd_server_side_copy_max_chunk_count() ||
-	    input_count < offsetof(struct copychunk_ioctl_req, Chunks) +
-	     chunk_count * sizeof(struct srv_copychunk)) {
-		rsp->hdr.Status = STATUS_INVALID_PARAMETER;
-		return -EINVAL;
-	}
+	if (chunk_count) {
+		/* verify the SRV_COPYCHUNK_COPY packet */
+		if (chunk_count > ksmbd_server_side_copy_max_chunk_count() ||
+		    input_count < offsetof(struct copychunk_ioctl_req, Chunks) +
+		     chunk_count * sizeof(struct srv_copychunk)) {
+			rsp->hdr.Status = STATUS_INVALID_PARAMETER;
+			return -EINVAL;
+		}
 
-	for (i = 0; i < chunk_count; i++) {
-		if (le32_to_cpu(chunks[i].Length) == 0 ||
-		    le32_to_cpu(chunks[i].Length) > ksmbd_server_side_copy_max_chunk_size())
-			break;
-		total_size_written += le32_to_cpu(chunks[i].Length);
+		for (i = 0; i < chunk_count; i++) {
+			if (le32_to_cpu(chunks[i].Length) == 0 ||
+			    le32_to_cpu(chunks[i].Length) > ksmbd_server_side_copy_max_chunk_size())
+				break;
+			total_size_written += le32_to_cpu(chunks[i].Length);
+		}
 	}
 
 	if (i < chunk_count ||

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4281,17 +4281,40 @@ static int smb2_populate_readdir_entry(struct ksmbd_conn *conn, int info_level,
 
 		fibdinfo = (struct file_id_both_directory_info *)kstat;
 		fibdinfo->FileNameLength = cpu_to_le32(conv_len);
-		fibdinfo->EaSize =
-			smb2_get_reparse_tag_special_file(ksmbd_kstat->kstat->mode);
-		if (fibdinfo->EaSize)
-			fibdinfo->ExtFileAttributes = ATTR_REPARSE_POINT_LE;
 		if (conn->is_aapl)
 			fibdinfo->UniqueId = 0;
 		else
 			fibdinfo->UniqueId = cpu_to_le64(ksmbd_kstat->kstat->ino);
 		fibdinfo->ShortNameLength = 0;
 		fibdinfo->Reserved = 0;
-		fibdinfo->Reserved2 = cpu_to_le16(0);
+		if (conn->aapl_readdir_attr) {
+			/*
+			 * READDIR_ATTR wire format, reverse-engineered from
+			 * macOS smbfs.kext network behavior:
+			 *   EaSize           = max_access (FILE_GENERIC_ALL, simplified)
+			 *   ShortName[0..7]  = resource fork size (uint64 LE, 0 = no rfork)
+			 *   ShortName[8..23] = compressed FinderInfo (type+creator+flags+
+			 *                      ext_flags+date_added, 16 bytes LE; all
+			 *                      zeros means type=0/creator=0, i.e. use
+			 *                      the file extension for icon lookup)
+			 *   Reserved2        = Unix mode bits (uint16 LE)
+			 * Reparse-point tag is indicated via ExtFileAttributes, not EaSize.
+			 */
+			__le32 reparse_tag =
+				smb2_get_reparse_tag_special_file(ksmbd_kstat->kstat->mode);
+
+			if (reparse_tag)
+				fibdinfo->ExtFileAttributes = ATTR_REPARSE_POINT_LE;
+			fibdinfo->EaSize = FILE_GENERIC_ALL_LE;
+			memset(fibdinfo->ShortName, 0, sizeof(fibdinfo->ShortName));
+			fibdinfo->Reserved2 = cpu_to_le16(ksmbd_kstat->kstat->mode & 0xffff);
+		} else {
+			fibdinfo->EaSize =
+				smb2_get_reparse_tag_special_file(ksmbd_kstat->kstat->mode);
+			if (fibdinfo->EaSize)
+				fibdinfo->ExtFileAttributes = ATTR_REPARSE_POINT_LE;
+			fibdinfo->Reserved2 = cpu_to_le16(0);
+		}
 		if (d_info->hide_dot_file && d_info->name[0] == '.')
 			fibdinfo->ExtFileAttributes |= ATTR_HIDDEN_LE;
 		memcpy(fibdinfo->FileName, conv_name, conv_len);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2527,6 +2527,25 @@ static noinline int smb2_set_stream_name_xattr(const struct path *path,
 		return 0;
 
 	if (fp->cdoption == FILE_OPEN_LE) {
+		if (!strcmp(stream_name, "AFP_AfpInfo")) {
+			/*
+			 * Synthesize an empty AFP_AfpInfo xattr on first access.
+			 * type=0/creator=0 tells macOS to use the file extension
+			 * for icon and type detection. Matches Samba vfs_fruit.
+			 */
+			static const u8 afpinfo_empty[60] = {
+				0x00, 0x05, 0x16, 0x07, /* magic  0x00051607 BE */
+				0x00, 0x02, 0x00, 0x00, /* version 0x00020000 BE */
+			};
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+			rc = ksmbd_vfs_setxattr(idmap, path, xattr_stream_name,
+#else
+			rc = ksmbd_vfs_setxattr(user_ns, path, xattr_stream_name,
+#endif
+						(void *)afpinfo_empty,
+						sizeof(afpinfo_empty), 0, false);
+			return rc < 0 ? rc : 0;
+		}
 		ksmbd_debug(SMB, "XATTR stream name lookup failed: %d\n", rc);
 		return -EBADF;
 	}

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2677,6 +2677,16 @@ static void smb2_update_xattrs(struct ksmbd_tree_connect *tcon,
 
 	rc = compat_ksmbd_vfs_get_dos_attrib_xattr(path, path->dentry, &da);
 	if (rc > 0) {
+		/*
+		 * Don't report a stale SPARSE bit (e.g. left over from a
+		 * previous client, or from before the share was reconfigured)
+		 * when the share isn't currently advertising sparse-file
+		 * support. TM sparsebundle band files rely on sparse status
+		 * being accurate, since macOS decides whether to use
+		 * FSCTL_SET_SPARSE based on it.
+		 */
+		if (!(server_conf.share_fake_fscaps & FILE_SUPPORTS_SPARSE_FILES))
+			da.attr &= ~ATTR_SPARSE;
 		fp->f_ci->m_fattr = cpu_to_le32(da.attr);
 		fp->create_time = da.create_time;
 		fp->itime = da.itime;

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2536,6 +2536,26 @@ static noinline int smb2_set_stream_name_xattr(const struct path *path,
 	return 0;
 }
 
+/*
+ * fp->stream.size is the byte length of the mangled xattr *name*
+ * (used as attr_name_len when looking the xattr up), not the size of
+ * the xattr's value. Reporting it as EndOfFile/AllocationSize for a
+ * stream handle is wrong -- query the xattr's actual value length
+ * instead.
+ */
+static loff_t ksmbd_stream_eof(struct ksmbd_file *fp)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	ssize_t slen = ksmbd_vfs_casexattr_len(file_mnt_idmap(fp->filp),
+#else
+	ssize_t slen = ksmbd_vfs_casexattr_len(mnt_user_ns(fp->filp->f_path.mnt),
+#endif
+					       fp->filp->f_path.dentry,
+					       fp->stream.name,
+					       fp->stream.size);
+	return slen < 0 ? 0 : (loff_t)slen;
+}
+
 static int smb2_remove_smb_xattrs(const struct path *path)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
@@ -3774,9 +3794,16 @@ reconnected_fp:
 	rsp->LastWriteTime = cpu_to_le64(time);
 	time = ksmbd_UnixTimeToNT(stat.ctime);
 	rsp->ChangeTime = cpu_to_le64(time);
-	rsp->AllocationSize = S_ISDIR(stat.mode) ? 0 :
-		cpu_to_le64(stat.blocks << 9);
-	rsp->EndofFile = S_ISDIR(stat.mode) ? 0 : cpu_to_le64(stat.size);
+	if (ksmbd_stream_fd(fp)) {
+		loff_t seof = ksmbd_stream_eof(fp);
+
+		rsp->AllocationSize = cpu_to_le64((u64)seof);
+		rsp->EndofFile = cpu_to_le64((u64)seof);
+	} else {
+		rsp->AllocationSize = S_ISDIR(stat.mode) ? 0 :
+			cpu_to_le64(stat.blocks << 9);
+		rsp->EndofFile = S_ISDIR(stat.mode) ? 0 : cpu_to_le64(stat.size);
+	}
 	rsp->FileAttributes = fp->f_ci->m_fattr;
 
 	rsp->Reserved2 = 0;
@@ -5127,8 +5154,10 @@ static int get_file_standard_info(struct smb2_query_info_rsp *rsp,
 		sinfo->AllocationSize = cpu_to_le64(stat.blocks << 9);
 		sinfo->EndOfFile = S_ISDIR(stat.mode) ? 0 : cpu_to_le64(stat.size);
 	} else {
-		sinfo->AllocationSize = cpu_to_le64(fp->stream.size);
-		sinfo->EndOfFile = cpu_to_le64(fp->stream.size);
+		loff_t seof = ksmbd_stream_eof(fp);
+
+		sinfo->AllocationSize = cpu_to_le64((u64)seof);
+		sinfo->EndOfFile = cpu_to_le64((u64)seof);
 	}
 	sinfo->NumberOfLinks = cpu_to_le32(get_nlink(&stat) - delete_pending);
 	sinfo->DeletePending = delete_pending;
@@ -5197,8 +5226,10 @@ static int get_file_all_info(struct ksmbd_work *work,
 			cpu_to_le64(stat.blocks << 9);
 		file_info->EndOfFile = S_ISDIR(stat.mode) ? 0 : cpu_to_le64(stat.size);
 	} else {
-		file_info->AllocationSize = cpu_to_le64(fp->stream.size);
-		file_info->EndOfFile = cpu_to_le64(fp->stream.size);
+		loff_t seof = ksmbd_stream_eof(fp);
+
+		file_info->AllocationSize = cpu_to_le64((u64)seof);
+		file_info->EndOfFile = cpu_to_le64((u64)seof);
 	}
 	file_info->NumberOfLinks =
 			cpu_to_le32(get_nlink(&stat) - delete_pending);
@@ -5403,8 +5434,10 @@ static int get_file_network_open_info(struct smb2_query_info_rsp *rsp,
 		file_info->AllocationSize = cpu_to_le64(stat.blocks << 9);
 		file_info->EndOfFile = S_ISDIR(stat.mode) ? 0 : cpu_to_le64(stat.size);
 	} else {
-		file_info->AllocationSize = cpu_to_le64(fp->stream.size);
-		file_info->EndOfFile = cpu_to_le64(fp->stream.size);
+		loff_t seof = ksmbd_stream_eof(fp);
+
+		file_info->AllocationSize = cpu_to_le64((u64)seof);
+		file_info->EndOfFile = cpu_to_le64((u64)seof);
 	}
 	file_info->Reserved = cpu_to_le32(0);
 	rsp->OutputBufferLength =
@@ -5535,8 +5568,10 @@ static int find_file_posix_info(struct smb2_query_info_rsp *rsp,
 		file_info->EndOfFile = cpu_to_le64(stat.size);
 		file_info->AllocationSize = cpu_to_le64(stat.blocks << 9);
 	} else {
-		file_info->EndOfFile = cpu_to_le64(fp->stream.size);
-		file_info->AllocationSize = cpu_to_le64(fp->stream.size);
+		loff_t seof = ksmbd_stream_eof(fp);
+
+		file_info->EndOfFile = cpu_to_le64((u64)seof);
+		file_info->AllocationSize = cpu_to_le64((u64)seof);
 	}
 	file_info->HardLinks = cpu_to_le32(stat.nlink);
 	file_info->Mode = cpu_to_le32(stat.mode & 0777);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -6854,9 +6854,9 @@ static int set_file_disposition_info(struct ksmbd_file *fp,
 		if (S_ISDIR(inode->i_mode) &&
 		    ksmbd_vfs_empty_dir(fp) == -ENOTEMPTY)
 			return -EBUSY;
-		ksmbd_set_inode_pending_delete(fp);
+		ksmbd_fd_set_delete_pending(fp);
 	} else {
-		ksmbd_clear_inode_pending_delete(fp);
+		ksmbd_fd_clear_delete_pending(fp);
 	}
 	return 0;
 }

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4299,9 +4299,11 @@ static int smb2_populate_readdir_entry(struct ksmbd_conn *conn, int info_level,
 		fibdinfo->Reserved = 0;
 		if (conn->aapl_readdir_attr) {
 			/*
-			 * READDIR_ATTR wire format, reverse-engineered from
-			 * macOS smbfs.kext network behavior:
-			 *   EaSize           = max_access (FILE_GENERIC_ALL, simplified)
+			 * READDIR_ATTR wire format, confirmed against Samba's
+			 * vfs_fruit marshalling (source3/smbd/smb2_trans2.c):
+			 *   EaSize           = max_access (expanded specific
+			 *                      rights, simplified to "grant all")
+			 *   ShortNameLength  = 24 (fixed; not 0, despite the spec)
 			 *   ShortName[0..7]  = resource fork size (uint64 LE, 0 = no rfork)
 			 *   ShortName[8..23] = compressed FinderInfo (type+creator+flags+
 			 *                      ext_flags+date_added, 16 bytes LE; all
@@ -4315,7 +4317,29 @@ static int smb2_populate_readdir_entry(struct ksmbd_conn *conn, int info_level,
 
 			if (reparse_tag)
 				fibdinfo->ExtFileAttributes = ATTR_REPARSE_POINT_LE;
-			fibdinfo->EaSize = FILE_GENERIC_ALL_LE;
+			/*
+			 * FILE_GENERIC_ALL_LE (0x10000000) is the raw
+			 * "generic all" meta-bit -- valid only in a
+			 * client's requested access mask, for the server
+			 * to expand. It has none of the specific FILE_*
+			 * rights bits set (FILE_LIST_DIRECTORY, FILE_TRAVERSE,
+			 * etc.), so reporting it here as max_access made
+			 * macOS's bit-by-bit access checks fail on every
+			 * entry -> permanent "no entry" badges in Finder.
+			 * Report the actual expanded rights instead, same
+			 * as smb_map_generic_desired_access() does when
+			 * translating a client's GENERIC_ALL request.
+			 */
+			fibdinfo->EaSize = cpu_to_le32(GENERIC_ALL_FLAGS);
+			/*
+			 * The spec says ShortNameLength should be 0 when
+			 * there's no short name, but real macOS clients
+			 * expect it set to 24 for READDIR_ATTR entries --
+			 * confirmed in Samba's vfs_fruit marshalling
+			 * (smb2_trans2.c): "on the wire behaviour shows
+			 * its set to 24 by clients."
+			 */
+			fibdinfo->ShortNameLength = 24;
 			memset(fibdinfo->ShortName, 0, sizeof(fibdinfo->ShortName));
 			fibdinfo->Reserved2 = cpu_to_le16(ksmbd_kstat->kstat->mode & 0xffff);
 		} else {

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -9423,6 +9423,9 @@ int smb2_notify(struct ksmbd_work *work)
 {
 	struct smb2_notify_req *req;
 	struct smb2_notify_rsp *rsp;
+	struct ksmbd_work *in_work;
+	struct smb2_hdr *in_hdr;
+	struct ksmbd_file *fp;
 
 	ksmbd_debug(SMB, "Received smb2 notify\n");
 
@@ -9434,9 +9437,108 @@ int smb2_notify(struct ksmbd_work *work)
 		return -EIO;
 	}
 
-	smb2_set_err_rsp(work);
-	rsp->hdr.Status = STATUS_NOT_IMPLEMENTED;
-	return -EOPNOTSUPP;
+	/*
+	 * macOS backupd sends CHANGE_NOTIFY with FileId=FFFF...FFFF (share-root
+	 * sentinel) to watch for changes on the share root without holding an
+	 * open handle. Respond STATUS_PENDING + STATUS_NOTIFY_CLEANUP immediately;
+	 * without this, backupd aborts Time Machine setup on STATUS_FILE_CLOSED.
+	 */
+	if (req->VolatileFileId == SMB2_NO_FID &&
+	    req->PersistentFileId == SMB2_NO_FID) {
+		in_work = ksmbd_alloc_work_struct();
+		if (!in_work || allocate_interim_rsp_buf(in_work)) {
+			if (in_work)
+				ksmbd_free_work_struct(in_work);
+			rsp->hdr.Status = STATUS_INSUFFICIENT_RESOURCES;
+			smb2_set_err_rsp(work);
+			return 0;
+		}
+		if (setup_async_work(work, NULL, NULL)) {
+			ksmbd_free_work_struct(in_work);
+			rsp->hdr.Status = STATUS_INSUFFICIENT_RESOURCES;
+			smb2_set_err_rsp(work);
+			return 0;
+		}
+		smb2_send_interim_resp(work, STATUS_PENDING);
+		in_work->conn = work->conn;
+		in_hdr = smb2_get_msg(in_work->response_buf);
+		memcpy(in_hdr, ksmbd_resp_buf_next(work),
+		       __SMB2_HEADER_STRUCTURE_SIZE);
+		in_hdr->Flags |= SMB2_FLAGS_ASYNC_COMMAND;
+		in_hdr->Id.AsyncId = cpu_to_le64(work->async_id);
+		smb2_set_err_rsp(in_work);
+		in_hdr->Status = STATUS_NOTIFY_CLEANUP;
+		in_work->async_id = work->async_id;
+		work->async_id = 0;
+		release_async_work(work);
+		ksmbd_conn_write(in_work);
+		ksmbd_free_work_struct(in_work);
+		work->send_no_response = 1;
+		return 0;
+	}
+
+	/*
+	 * KSMBD does not implement a real change-notification backend.
+	 * Genuine SMB2 servers (and macOS smbfs) never complete a
+	 * CHANGE_NOTIFY spontaneously: it is satisfied only by a real
+	 * directory change, or with STATUS_NOTIFY_CLEANUP when the watched
+	 * handle is closed. Completing it early (e.g. on a timer) makes
+	 * Finder treat the cleanup as "directory changed" and re-enumerate
+	 * the directory forever, leaving items unopenable. Returning
+	 * STATUS_NOT_IMPLEMENTED here (like stock ksmbd) makes macOS smbfs
+	 * hard-freeze on unmount, so this must stay deferred.
+	 */
+	fp = ksmbd_lookup_fd_slow(work, req->VolatileFileId, req->PersistentFileId);
+	if (!fp) {
+		rsp->hdr.Status = STATUS_FILE_CLOSED;
+		smb2_set_err_rsp(work);
+		return 0;
+	}
+
+	in_work = ksmbd_alloc_work_struct();
+	if (!in_work || allocate_interim_rsp_buf(in_work)) {
+		if (in_work)
+			ksmbd_free_work_struct(in_work);
+		ksmbd_fd_put(work, fp);
+		rsp->hdr.Status = STATUS_INSUFFICIENT_RESOURCES;
+		smb2_set_err_rsp(work);
+		return 0;
+	}
+
+	if (setup_async_work(work, NULL, NULL)) {
+		ksmbd_free_work_struct(in_work);
+		ksmbd_fd_put(work, fp);
+		rsp->hdr.Status = STATUS_INSUFFICIENT_RESOURCES;
+		smb2_set_err_rsp(work);
+		return 0;
+	}
+
+	smb2_send_interim_resp(work, STATUS_PENDING);
+
+	in_work->conn = work->conn;
+	in_hdr = smb2_get_msg(in_work->response_buf);
+	memcpy(in_hdr, ksmbd_resp_buf_next(work), __SMB2_HEADER_STRUCTURE_SIZE);
+	in_hdr->Flags |= SMB2_FLAGS_ASYNC_COMMAND;
+	in_hdr->Id.AsyncId = cpu_to_le64(work->async_id);
+	smb2_set_err_rsp(in_work);
+	in_hdr->Status = STATUS_NOTIFY_CLEANUP;
+
+	/*
+	 * Transfer ownership of the async id to in_work; it stays reserved
+	 * until in_work is freed after the deferred response is sent on
+	 * close, so it can't be reused for an unrelated async response.
+	 */
+	in_work->async_id = work->async_id;
+	work->async_id = 0;
+	release_async_work(work);
+
+	spin_lock(&fp->f_lock);
+	list_add_tail(&in_work->notify_entry, &fp->notify_pendings);
+	spin_unlock(&fp->f_lock);
+
+	ksmbd_fd_put(work, fp);
+	work->send_no_response = 1;
+	return 0;
 }
 
 /**

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -8852,7 +8852,7 @@ int smb2_ioctl(struct ksmbd_work *work)
 			goto out;
 		}
 
-		if (in_buf_len <= sizeof(struct copychunk_ioctl_req)) {
+		if (in_buf_len < offsetof(struct copychunk_ioctl_req, Chunks)) {
 			ret = -EINVAL;
 			goto out;
 		}

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2995,6 +2995,8 @@ int smb2_open(struct ksmbd_work *work)
 	int rc = 0;
 	int contxt_cnt = 0, query_disk_id = 0;
 	bool maximal_access_ctxt = false, posix_ctxt = false;
+	bool aapl_ctxt = false;
+	__u64 aapl_req_bitmap = 0, aapl_client_caps = 0;
 	int s_type = 0;
 	int next_off = 0;
 	char *name = NULL;
@@ -3736,7 +3738,32 @@ int smb2_open(struct ksmbd_work *work)
 			query_disk_id = 1;
 		}
 
-		if (conn->is_aapl == false) {
+		if (test_share_config_flag(share, KSMBD_SHARE_FLAG_TIME_MACHINE)) {
+			context = smb2_find_context_vals(req, SMB2_CREATE_AAPL, 4);
+			if (IS_ERR(context)) {
+				rc = PTR_ERR(context);
+				goto err_out1;
+			} else if (context) {
+				struct aapl_server_query_req *aapl_req;
+
+				if (le16_to_cpu(context->DataOffset) +
+				    le32_to_cpu(context->DataLength) <
+				    sizeof(struct aapl_server_query_req)) {
+					rc = -EINVAL;
+					goto err_out1;
+				}
+
+				aapl_req = (struct aapl_server_query_req *)
+					((char *)context +
+					 le16_to_cpu(context->DataOffset));
+				if (le32_to_cpu(aapl_req->cmd) == AAPL_SERVER_QUERY) {
+					conn->is_aapl = true;
+					aapl_ctxt = true;
+					aapl_req_bitmap = le64_to_cpu(aapl_req->req_bitmap);
+					aapl_client_caps = le64_to_cpu(aapl_req->client_caps);
+				}
+			}
+		} else if (conn->is_aapl == false) {
 			context = smb2_find_context_vals(req, SMB2_CREATE_AAPL, 4);
 			if (IS_ERR(context)) {
 				rc = PTR_ERR(context);
@@ -3911,6 +3938,10 @@ reconnected_fp:
 	}
 
 	if (posix_ctxt) {
+		struct create_context *posix_ccontext;
+
+		posix_ccontext = (struct create_context *)(rsp->Buffer +
+				le32_to_cpu(rsp->CreateContextsLength));
 		contxt_cnt++;
 		create_posix_rsp_buf(rsp->Buffer +
 				le32_to_cpu(rsp->CreateContextsLength),
@@ -3920,6 +3951,29 @@ reconnected_fp:
 		iov_len += conn->vals->create_posix_size;
 		if (next_ptr)
 			*next_ptr = cpu_to_le32(next_off);
+		next_ptr = &posix_ccontext->Next;
+		next_off = conn->vals->create_posix_size;
+	}
+
+	/*
+	 * AAPL create context response: see smb2pdu.h for the capability
+	 * rationale. Scoped to TIME_MACHINE shares only.
+	 */
+	if (aapl_ctxt) {
+		if (aapl_client_caps & AAPL_CAPS_READDIR_ATTR)
+			conn->aapl_readdir_attr = true;
+
+		contxt_cnt++;
+		create_aapl_rsp_buf(rsp->Buffer +
+				le32_to_cpu(rsp->CreateContextsLength),
+				AAPL_VOLCAPS_FULL_SYNC,
+				aapl_req_bitmap);
+		le32_add_cpu(&rsp->CreateContextsLength,
+			     conn->vals->create_aapl_size);
+		iov_len += conn->vals->create_aapl_size;
+		if (next_ptr)
+			*next_ptr = cpu_to_le32(next_off);
+		/* AAPL is last; next_ptr need not be updated */
 	}
 
 	if (contxt_cnt > 0) {

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -581,6 +581,62 @@ struct smb2_tree_disconnect_rsp {
 /* Apple Defined Contexts */
 #define	SMB2_CREATE_AAPL			"AAPL"
 
+/*
+ * Apple AAPL SMB2 extension -- kAAPL_SERVER_QUERY create context.
+ *
+ * Omitting the model string when reply_bitmap includes AAPL_BITMAP_MODEL_INFO
+ * causes smbfs.kext to enter a broken disconnect path requiring a reboot.
+ *
+ * Layout: ccontext(16) + Name[4] + Pad[4] + cmd(4) + reserved(4) +
+ *         reply_bitmap(8) + server_caps(8) + vol_caps(8)
+ * When MODEL_INFO requested, appended: pad2(4) + model_bytes(4) + UTF-16LE
+ */
+#define AAPL_CTX_NAME_OFF	16	/* sizeof(struct create_context) */
+#define AAPL_CTX_DATA_OFF	24	/* ALIGN(16 + 4, 8) */
+#define SMB2_CREATE_AAPL_LEN	4
+
+#define AAPL_SERVER_QUERY	1
+
+#define AAPL_BITMAP_SERVER_CAPS	0x01ULL
+#define AAPL_BITMAP_VOL_CAPS	0x02ULL
+#define AAPL_BITMAP_MODEL_INFO	0x04ULL
+
+/* Server capability flags (server_caps field) */
+#define AAPL_CAPS_READDIR_ATTR	0x01ULL  /* inline FinderInfo per FIND entry */
+#define AAPL_CAPS_COPYFILE	0x02ULL  /* FSCTL_SRV_COPYCHUNK for Cmd+D */
+#define AAPL_CAPS_UNIX_BASED	0x04ULL  /* server is Unix-based */
+
+/*
+ * UNIX_BASED: prevents macOS Windows-compat mode (question-mark icons).
+ * COPYFILE: enables server-side file copy via FSCTL_SRV_COPYCHUNK.
+ * READDIR_ATTR: inline FinderInfo per FIND entry, set when client also
+ *   advertises the bit; format: EaSize=max_access, ShortName[0..7]=rfork_size,
+ *   ShortName[8..23]=FinderInfo(16B), Reserved2=unix_mode.
+ */
+#define AAPL_SERVER_CAPS_KSMBD	(AAPL_CAPS_UNIX_BASED | AAPL_CAPS_COPYFILE | \
+				 AAPL_CAPS_READDIR_ATTR)
+
+/* Volume capability flags (vol_caps field) */
+#define AAPL_VOLCAPS_FULL_SYNC	0x04ULL  /* SMB2 FLUSH maps to F_FULLFSYNC */
+
+/* Model string: up to 31 ASCII chars */
+#define AAPL_MODEL_MAX_CHARS	31
+#define AAPL_MODEL_UTF16_BYTES	(AAPL_MODEL_MAX_CHARS * 2)
+
+/*
+ * Max AAPL response: header(24) + base data(32) + pad2(4) + model_bytes(4)
+ * + model(62), 8-byte aligned: ALIGN(126, 8) = 128 bytes.
+ */
+#define AAPL_RSP_MAX_SIZE	128
+
+/* AAPL server query request (client->server) */
+struct aapl_server_query_req {
+	__le32 cmd;
+	__le32 reserved;
+	__le64 req_bitmap;
+	__le64 client_caps;
+} __packed;
+
 struct smb2_create_req {
 	struct smb2_hdr hdr;
 	__le16 StructureSize;	/* Must be 57 */
@@ -630,6 +686,18 @@ struct create_context {
 	__le16 DataOffset;
 	__le32 DataLength;
 	__u8 Buffer[0];
+} __packed;
+
+struct create_aapl_rsp {
+	struct create_context ccontext;
+	__u8   Name[4];
+	__u8   Pad[4];
+	__le32 cmd;
+	__le32 reserved;
+	__le64 reply_bitmap;
+	__le64 server_caps;
+	__le64 vol_caps;
+	/* when AAPL_BITMAP_MODEL_INFO: __le32 pad2; __le32 model_bytes; __le16 model[] */
 } __packed;
 
 struct create_durable_req_v2 {

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -610,8 +610,14 @@ struct smb2_tree_disconnect_rsp {
  * UNIX_BASED: prevents macOS Windows-compat mode (question-mark icons).
  * COPYFILE: enables server-side file copy via FSCTL_SRV_COPYCHUNK.
  * READDIR_ATTR: inline FinderInfo per FIND entry, set when client also
- *   advertises the bit; format: EaSize=max_access, ShortName[0..7]=rfork_size,
- *   ShortName[8..23]=FinderInfo(16B), Reserved2=unix_mode.
+ *   advertises the bit; format confirmed against Samba's vfs_fruit
+ *   (source3/smbd/smb2_trans2.c): EaSize=max_access, ShortNameLength=24
+ *   (fixed, despite spec saying 0), ShortName[0..7]=rfork_size,
+ *   ShortName[8..23]=FinderInfo(16B), Reserved2=unix_mode. The
+ *   max_access value must be an expanded specific-rights mask
+ *   (GENERIC_ALL_FLAGS), not the raw FILE_GENERIC_ALL_LE "generic"
+ *   meta-bit -- see smb2pdu.c FILEID_BOTH_DIRECTORY_INFORMATION
+ *   handling for why.
  */
 #define AAPL_SERVER_CAPS_KSMBD	(AAPL_CAPS_UNIX_BASED | AAPL_CAPS_COPYFILE | \
 				 AAPL_CAPS_READDIR_ATTR)

--- a/smb_common.h
+++ b/smb_common.h
@@ -455,6 +455,7 @@ struct smb_version_values {
 	size_t		create_mxac_size;
 	size_t		create_disk_id_size;
 	size_t		create_posix_size;
+	size_t		create_aapl_size;
 };
 
 struct filesystem_posix_info {

--- a/transport_ipc.c
+++ b/transport_ipc.c
@@ -324,6 +324,15 @@ static int ipc_server_config_on_startup(struct ksmbd_startup_request *req)
 		goto out;
 	}
 	server_conf.share_fake_fscaps = req->share_fake_fscaps;
+
+	/* AAPL model string for Finder icon */
+	if (req->aapl_model[0])
+		strscpy(server_conf.aapl_model, req->aapl_model,
+			sizeof(server_conf.aapl_model));
+	else
+		strscpy(server_conf.aapl_model, "Xserve",
+			sizeof(server_conf.aapl_model));
+
 	ksmbd_init_domain(req->sub_auth);
 
 	if (req->smb2_max_read)

--- a/vfs.c
+++ b/vfs.c
@@ -3414,6 +3414,13 @@ int ksmbd_vfs_copy_file_ranges(struct ksmbd_work *work,
 				return sret;
 		}
 
+		if (chunk_count == 0) {
+			/* AAPL full-stream-copy request: report actual bytes copied. */
+			*chunk_count_written = 1;
+			*total_size_written = buf_len;
+			return 0;
+		}
+
 		/*
 		 * macOS reuses the main file's chunk list for stream copies,
 		 * so req_total equals the file size, not the stream size.
@@ -3428,6 +3435,46 @@ int ksmbd_vfs_copy_file_ranges(struct ksmbd_work *work,
 	}
 
 	smb_break_all_levII_oplock(work, dst_fp, 1);
+
+	/*
+	 * macOS Finder's Cmd+D duplicate sends FSCTL_SRV_COPYCHUNK with
+	 * ChunkCount=0 meaning "copy the whole file", not the standard
+	 * SMB2 "query my copy limits, no data" semantics -- fsctl_copychunk()
+	 * only reaches here with chunk_count == 0 for AAPL-negotiated
+	 * connections, so this doesn't affect compliant non-Apple clients.
+	 * Without this, the destination stays at its just-created 0 bytes.
+	 */
+	if (chunk_count == 0) {
+		loff_t size = i_size_read(file_inode(src_fp->filp));
+		loff_t off = 0;
+
+		while (off < size) {
+			ssize_t copied = vfs_copy_file_range(src_fp->filp, off,
+					dst_fp->filp, off, size - off, 0);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 0)
+			if (copied == -EOPNOTSUPP || copied == -EXDEV)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+				copied = vfs_copy_file_range(src_fp->filp, off,
+						dst_fp->filp, off,
+						size - off, COPY_FILE_SPLICE);
+#else
+				copied = generic_copy_file_range(src_fp->filp, off,
+						dst_fp->filp, off,
+						size - off, 0);
+#endif
+#endif
+			if (copied < 0)
+				return copied;
+			if (copied == 0)
+				break;
+			off += copied;
+		}
+
+		*chunk_count_written = 1;
+		*chunk_size_written = (unsigned int)min_t(loff_t, size, UINT_MAX);
+		*total_size_written = off;
+		return 0;
+	}
 
 	if (!work->tcon->posix_extensions) {
 		for (i = 0; i < chunk_count; i++) {

--- a/vfs.c
+++ b/vfs.c
@@ -719,6 +719,10 @@ int ksmbd_vfs_read(struct ksmbd_work *work, struct ksmbd_file *fp, size_t count,
 	ssize_t nbytes = 0;
 	struct inode *inode = file_inode(filp);
 
+	/* Stream (xattr) reads work on directories too; check before S_ISDIR */
+	if (ksmbd_stream_fd(fp))
+		return ksmbd_vfs_stream_read(fp, rbuf, pos, count);
+
 	if (S_ISDIR(inode->i_mode))
 		return -EISDIR;
 
@@ -731,9 +735,6 @@ int ksmbd_vfs_read(struct ksmbd_work *work, struct ksmbd_file *fp, size_t count,
 			return -EACCES;
 		}
 	}
-
-	if (ksmbd_stream_fd(fp))
-		return ksmbd_vfs_stream_read(fp, rbuf, pos, count);
 
 	if (!work->tcon->posix_extensions) {
 		int ret;
@@ -3372,8 +3373,59 @@ int ksmbd_vfs_copy_file_ranges(struct ksmbd_work *work,
 		return -EACCES;
 	}
 
-	if (ksmbd_stream_fd(src_fp) || ksmbd_stream_fd(dst_fp))
-		return -EBADF;
+	if (ksmbd_stream_fd(src_fp) || ksmbd_stream_fd(dst_fp)) {
+		/*
+		 * ADS stream copychunk: copy xattr from src to dst directly.
+		 * vfs_copy_file_range doesn't work on xattr-backed streams.
+		 */
+		char *buf = NULL;
+		ssize_t buf_len;
+		int sret;
+
+		if (!ksmbd_stream_fd(src_fp) || !ksmbd_stream_fd(dst_fp))
+			return -EINVAL;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+		buf_len = ksmbd_vfs_getxattr(file_mnt_idmap(src_fp->filp),
+#else
+		buf_len = ksmbd_vfs_getxattr(file_mnt_user_ns(src_fp->filp),
+#endif
+					     file_dentry(src_fp->filp),
+					     src_fp->stream.name, &buf);
+		if (buf_len < 0)
+			return buf_len;
+
+		if (buf_len > 0) {
+			/*
+			 * vfs_setxattr(NULL, 0) removes the xattr on Linux, so
+			 * skip it for empty streams: the Open already created
+			 * the empty xattr via smb2_set_stream_name_xattr.
+			 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+			sret = ksmbd_vfs_setxattr(file_mnt_idmap(dst_fp->filp),
+#else
+			sret = ksmbd_vfs_setxattr(file_mnt_user_ns(dst_fp->filp),
+#endif
+						  &dst_fp->filp->f_path,
+						  dst_fp->stream.name,
+						  buf, buf_len, 0, false);
+			kfree(buf);
+			if (sret < 0)
+				return sret;
+		}
+
+		/*
+		 * macOS reuses the main file's chunk list for stream copies,
+		 * so req_total equals the file size, not the stream size.
+		 * Echo back TotalBytesWritten = sum(chunks) so macOS doesn't
+		 * treat the size mismatch as an error.
+		 */
+		*chunk_count_written = chunk_count;
+		*total_size_written = 0;
+		for (i = 0; i < chunk_count; i++)
+			*total_size_written += le32_to_cpu(chunks[i].Length);
+		return 0;
+	}
 
 	smb_break_all_levII_oplock(work, dst_fp, 1);
 

--- a/vfs_cache.c
+++ b/vfs_cache.c
@@ -442,11 +442,26 @@ static void __ksmbd_close_fd(struct ksmbd_file_table *ft, struct ksmbd_file *fp)
 	 * (no real change-notification backend), only on close -- matching
 	 * genuine SMB2/macOS smbfs semantics and avoiding the Finder
 	 * "directory changed, re-enumerate everything" loop.
+	 *
+	 * smb2_notify() on another connection can be adding to
+	 * notify_pendings under fp->f_lock at the same time this handle is
+	 * closed. Splice the list out under that same lock before touching
+	 * it, instead of walking it unlocked -- ksmbd_conn_write() can sleep
+	 * (it takes conn's write mutex), so it must not be called while
+	 * fp->f_lock is held.
 	 */
-	list_for_each_entry_safe(cn_work, cn_tmp, &fp->notify_pendings, notify_entry) {
-		list_del_init(&cn_work->notify_entry);
-		ksmbd_conn_write(cn_work);
-		ksmbd_free_work_struct(cn_work);
+	{
+		LIST_HEAD(cn_dispose);
+
+		spin_lock(&fp->f_lock);
+		list_splice_init(&fp->notify_pendings, &cn_dispose);
+		spin_unlock(&fp->f_lock);
+
+		list_for_each_entry_safe(cn_work, cn_tmp, &cn_dispose, notify_entry) {
+			list_del_init(&cn_work->notify_entry);
+			ksmbd_conn_write(cn_work);
+			ksmbd_free_work_struct(cn_work);
+		}
 	}
 #ifdef CONFIG_SMB_INSECURE_SERVER
 	kfree(fp->filename);

--- a/vfs_cache.c
+++ b/vfs_cache.c
@@ -396,10 +396,6 @@ static void __ksmbd_remove_fd(struct ksmbd_file_table *ft, struct ksmbd_file *fp
 	if (!has_file_id(fp->volatile_id))
 		return;
 
-	down_write(&fp->f_ci->m_lock);
-	list_del_init(&fp->node);
-	up_write(&fp->f_ci->m_lock);
-
 	write_lock(&ft->lock);
 	idr_remove(ft->idr, fp->volatile_id);
 	write_unlock(&ft->lock);
@@ -415,6 +411,19 @@ static void __ksmbd_close_fd(struct ksmbd_file_table *ft, struct ksmbd_file *fp)
 	ksmbd_remove_durable_fd(fp);
 	if (ft)
 		__ksmbd_remove_fd(ft, fp);
+
+	/*
+	 * fp stays linked into f_ci->m_fp_list (checked by
+	 * ksmbd_smb_check_shared_mode() on every open) regardless of which
+	 * file table it belongs to -- including durable handles closed by
+	 * the scavenger with ft == NULL. Unlink it here unconditionally;
+	 * leaving it linked would corrupt m_fp_list once fp is freed below.
+	 */
+	if (has_file_id(fp->volatile_id)) {
+		down_write(&fp->f_ci->m_lock);
+		list_del_init(&fp->node);
+		up_write(&fp->f_ci->m_lock);
+	}
 
 	close_id_del_oplock(fp);
 	filp = fp->filp;
@@ -772,6 +781,7 @@ struct ksmbd_file *ksmbd_open_fd(struct ksmbd_work *work, struct file *filp)
 
 	INIT_LIST_HEAD(&fp->blocked_works);
 	INIT_LIST_HEAD(&fp->node);
+	INIT_LIST_HEAD(&fp->dh_scavenger_entry);
 	INIT_LIST_HEAD(&fp->lock_list);
 	INIT_LIST_HEAD(&fp->notify_pendings);
 	spin_lock_init(&fp->f_lock);
@@ -909,8 +919,8 @@ static void ksmbd_scavenger_dispose_dh(struct list_head *head)
 	while (!list_empty(head)) {
 		struct ksmbd_file *fp;
 
-		fp = list_first_entry(head, struct ksmbd_file, node);
-		list_del_init(&fp->node);
+		fp = list_first_entry(head, struct ksmbd_file, dh_scavenger_entry);
+		list_del_init(&fp->dh_scavenger_entry);
 		__ksmbd_close_fd(NULL, fp);
 	}
 }
@@ -954,7 +964,7 @@ static int ksmbd_durable_scavenger(void *dummy)
 			if (fp->durable_scavenger_timeout <=
 			    jiffies_to_msecs(jiffies)) {
 				__ksmbd_remove_durable_fd(fp);
-				list_add(&fp->node, &scavenger_list);
+				list_add(&fp->dh_scavenger_entry, &scavenger_list);
 			} else {
 				unsigned long durable_timeout;
 

--- a/vfs_cache.c
+++ b/vfs_cache.c
@@ -173,6 +173,38 @@ void ksmbd_fd_set_delete_on_close(struct ksmbd_file *fp,
 	up_write(&ci->m_lock);
 }
 
+/*
+ * FileDispositionInformation (SET_INFO) on a stream handle must only
+ * mark the stream for deletion, not the whole file -- otherwise
+ * deleting a single alternate data stream (e.g. AFP_AfpInfo) deletes
+ * the entire file's data along with it.
+ */
+void ksmbd_fd_set_delete_pending(struct ksmbd_file *fp)
+{
+	struct ksmbd_inode *ci = fp->f_ci;
+
+	if (ksmbd_stream_fd(fp)) {
+		down_write(&ci->m_lock);
+		ci->m_flags |= S_DEL_ON_CLS_STREAM;
+		up_write(&ci->m_lock);
+	} else {
+		ksmbd_set_inode_pending_delete(fp);
+	}
+}
+
+void ksmbd_fd_clear_delete_pending(struct ksmbd_file *fp)
+{
+	struct ksmbd_inode *ci = fp->f_ci;
+
+	if (ksmbd_stream_fd(fp)) {
+		down_write(&ci->m_lock);
+		ci->m_flags &= ~S_DEL_ON_CLS_STREAM;
+		up_write(&ci->m_lock);
+	} else {
+		ksmbd_clear_inode_pending_delete(fp);
+	}
+}
+
 static void ksmbd_inode_hash(struct ksmbd_inode *ci)
 {
 	struct hlist_head *b = inode_hashtable +

--- a/vfs_cache.c
+++ b/vfs_cache.c
@@ -409,6 +409,7 @@ static void __ksmbd_close_fd(struct ksmbd_file_table *ft, struct ksmbd_file *fp)
 {
 	struct file *filp;
 	struct ksmbd_lock *smb_lock, *tmp_lock;
+	struct ksmbd_work *cn_work, *cn_tmp;
 
 	fd_limit_close();
 	ksmbd_remove_durable_fd(fp);
@@ -433,6 +434,19 @@ static void __ksmbd_close_fd(struct ksmbd_file_table *ft, struct ksmbd_file *fp)
 		list_del(&smb_lock->flist);
 		locks_free_lock(smb_lock->fl);
 		kfree(smb_lock);
+	}
+
+	/*
+	 * Complete any CHANGE_NOTIFY left pending on this handle now that
+	 * it is closed. KSMBD never completes CHANGE_NOTIFY spontaneously
+	 * (no real change-notification backend), only on close -- matching
+	 * genuine SMB2/macOS smbfs semantics and avoiding the Finder
+	 * "directory changed, re-enumerate everything" loop.
+	 */
+	list_for_each_entry_safe(cn_work, cn_tmp, &fp->notify_pendings, notify_entry) {
+		list_del_init(&cn_work->notify_entry);
+		ksmbd_conn_write(cn_work);
+		ksmbd_free_work_struct(cn_work);
 	}
 #ifdef CONFIG_SMB_INSECURE_SERVER
 	kfree(fp->filename);
@@ -744,6 +758,7 @@ struct ksmbd_file *ksmbd_open_fd(struct ksmbd_work *work, struct file *filp)
 	INIT_LIST_HEAD(&fp->blocked_works);
 	INIT_LIST_HEAD(&fp->node);
 	INIT_LIST_HEAD(&fp->lock_list);
+	INIT_LIST_HEAD(&fp->notify_pendings);
 	spin_lock_init(&fp->f_lock);
 	atomic_set(&fp->refcount, 1);
 

--- a/vfs_cache.h
+++ b/vfs_cache.h
@@ -98,6 +98,14 @@ struct ksmbd_file {
 
 	struct stream			stream;
 	struct list_head		node;
+	/*
+	 * Durable-handle scavenger's temporary dispose list linkage.
+	 * Deliberately separate from `node' (which stays linked into
+	 * f_ci->m_fp_list until the file is actually closed) -- reusing
+	 * `node' here would silently corrupt m_fp_list the moment a durable
+	 * handle times out while still registered on its inode.
+	 */
+	struct list_head		dh_scavenger_entry;
 	struct list_head		blocked_works;
 	struct list_head		lock_list;
 

--- a/vfs_cache.h
+++ b/vfs_cache.h
@@ -203,6 +203,8 @@ void ksmbd_set_inode_pending_delete(struct ksmbd_file *fp);
 void ksmbd_clear_inode_pending_delete(struct ksmbd_file *fp);
 void ksmbd_fd_set_delete_on_close(struct ksmbd_file *fp,
 				  int file_info);
+void ksmbd_fd_set_delete_pending(struct ksmbd_file *fp);
+void ksmbd_fd_clear_delete_pending(struct ksmbd_file *fp);
 int ksmbd_reopen_durable_fd(struct ksmbd_work *work, struct ksmbd_file *fp);
 int ksmbd_validate_name_reconnect(struct ksmbd_share_config *share,
 				  struct ksmbd_file *fp, char *name);

--- a/vfs_cache.h
+++ b/vfs_cache.h
@@ -128,6 +128,12 @@ struct ksmbd_file {
 	bool				is_resilient;
 
 	bool                            is_posix_ctxt;
+
+	/*
+	 * Pending CHANGE_NOTIFY completions for this handle, sent with
+	 * STATUS_NOTIFY_CLEANUP when the handle is closed.
+	 */
+	struct list_head		notify_pendings;
 };
 
 static inline void set_ctx_actor(struct dir_context *ctx,


### PR DESCRIPTION
## Summary

Adds macOS Time Machine / AAPL support to ksmbd, which doesn't currently implement Apple's SMB extensions at all. This was built and tested against a real Time Machine backup and everyday Finder use; along the way I also found and fixed several bugs unrelated to Apple support that affect any client.

**AAPL / Time Machine:**
- Negotiate the AAPL create context, scoped to `KSMBD_SHARE_FLAG_TIME_MACHINE` shares (not global, since the extension only matters for Time Machine use)
- Synthesize AFP_AfpInfo xattr so Finder shows correct file icons instead of generic ones
- READDIR_ATTR: inline FinderInfo in directory listings, avoiding a round trip per file when Finder browses a folder
- Fix READDIR_ATTR's max_access value, which caused false "no entry" badges on every file/folder (it reported a raw GENERIC_ALL meta-bit instead of the actual expanded access rights)
- Defer CHANGE_NOTIFY instead of STATUS_NOT_IMPLEMENTED (macOS otherwise hard-freezes on unmount, and Time Machine's backupd aborts setup)
- COPYCHUNK: treat ChunkCount=0 as a full-file copy for AAPL clients, since Finder's Cmd+D duplicate sends ChunkCount=0 expecting a full copy rather than the standard "query my limits" no-op

**Other fixes found during testing** (not specific to Apple clients):
- Don't hold `m_lock` across a lease-break wait in parent notify — was blocking every other create/delete/rename under the same parent directory for up to 35s whenever one client was slow to acknowledge
- Route stream FileDispositionInformation through a stream delete flag instead of deleting the whole file when only a stream should be deleted
- Fix an off-by-one rejecting a minimal, valid COPYCHUNK query-limits request
- Report the actual xattr value length for stream EndOfFile/AllocationSize instead of the length of the xattr's name
- Return STATUS_OBJECT_NAME_NOT_FOUND for unknown IPC pipe names instead of STATUS_INVALID_PARAMETER, which was aborting Time Machine's backupd (see #502)
- Fix stream reads on directories, and COPYCHUNK when either side of the copy is a stream
- Quiet mdssvc RPC log spam, and fix a stale sparse-file attribute left over after a share's sparse-file support is reconfigured
- Fix an unlocked list race in the CHANGE_NOTIFY code — a notify request on one connection and a close on another could mutate the same list with no shared lock, which is what actually caused a server hang overnight during testing
- Fix the durable-handle scavenger corrupting a file's shared-mode list on handle timeout — caused a second overnight server crash (soft lockup, then a kernel oops) during backup testing

## References

- [Apple's Time Machine over SMB spec](https://developer.apple.com/library/archive/releasenotes/NetworkingInternetWeb/Time_Machine_SMB_Spec/) (also linked in #502) — confirms the AAPL bitmap values used here, and that only the FULL_SYNC vol_caps bit is required for Time Machine support
- Samba's `vfs_fruit`/`smb2_trans2.c` — since Apple doesn't document READDIR_ATTR, this was checked against Samba's own working implementation to fix the max_access bug above

## Test plan

- [x] All commits build cleanly against `master`
- [x] The full feature set was extensively live-tested against real Time Machine backups and Finder use during development
- [x] This series (re-derived against current `master`) has been live-tested: Finder browsing, folder access, and Cmd+D duplicate all confirmed working
- [x] A full end-to-end Time Machine backup completed successfully with this exact series, after the durable-handle fix above resolved a server crash from an earlier attempt

Claude was used throughout this work, for the original implementation and live debugging against real Time Machine/Finder sessions, and separately for re-deriving this patch series against the current master since it had diverged from the kernel tree the original work was based on. I am available to pursue the testing and answer myself to any comment or question.

🤖 Generated with the assistance of [Claude Code](https://claude.com/claude-code)
